### PR TITLE
More control over reader configuration (backwards-compatible)

### DIFF
--- a/templates/suricata.yaml.in
+++ b/templates/suricata.yaml.in
@@ -80,6 +80,16 @@ outputs:
         {% when EveConfiguration::Uds with (val) %}
       filetype: unix_stream
       filename: {{ val.path.to_string_lossy() }}
+        {% when EveConfiguration::Custom with (custom) %}
+      filetype: {{ custom.name }}
+          {% for option in custom.options %}
+        {{ option.key }}: {{ option.value }}
+          {% endfor %}
+          {% match custom.uds %}
+            {% when Some with (uds) %}
+        filename: {{ uds.path.to_string_lossy() }}
+            {% when None %}
+          {% endmatch %}
         {% when EveConfiguration::Redis with (val) %}
       filetype: redis
       redis:
@@ -1133,3 +1143,10 @@ ipc:
 # You can specify more than 2 configuration files, if needed.
 #include: include1.yaml
 #include: include2.yaml
+
+{% if plugins.len() > 0 %}
+plugins:
+{%- for plugin in plugins %}
+  - {{ plugin }}
+{%- endfor %}
+{% endif %}


### PR DESCRIPTION
On my machine `ids_process_4sics` is failing but it looks like it's just b/c of dropped packets...

Edit: same test fails on my machine on master