### PR TITLE
Allow for additional configs into suricata.yaml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suricata-ipc"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["dbcfd <bdbrowning2@gmail.com>"]
 edition = "2018"
 description = "Library for sending packets to suricata and receiving output."

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,6 +45,21 @@ struct RenderedPlugin<'a> {
     config: String,
 }
 
+#[derive(Clone)]
+pub enum AdditionalConfig {
+    String(String),
+    IncludePath(PathBuf),
+}
+
+impl std::fmt::Display for AdditionalConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::String(s) => write!(f, "{}", s),
+            Self::IncludePath(path) => write!(f, "include: {:?}", path.as_path())
+        }
+    }
+}
+
 #[derive(Template)]
 #[template(path = "suricata.yaml.in", escape = "none")]
 struct ConfigTemplate<'a> {
@@ -61,6 +76,7 @@ struct ConfigTemplate<'a> {
     detect_profile: DetectProfile,
     async_oneside: bool,
     filestore: &'a str,
+    additional_configs: Vec<AdditionalConfig>,
 }
 
 /// Runmodes for suricata
@@ -149,6 +165,8 @@ pub struct Config {
     pub async_oneside: bool,
     /// filestore configuration
     pub filestore: filestore::Filestore,
+    /// Additional configs, allow raw string or `include` to be appended to the suricata.yaml
+    pub additional_configs: Vec<AdditionalConfig>,
 }
 
 impl Default for Config {
@@ -211,6 +229,7 @@ impl Default for Config {
             detect_profile: DetectProfile::Medium,
             async_oneside: false,
             filestore: filestore::Filestore::default(),
+            additional_configs: vec![],
         }
     }
 }
@@ -262,6 +281,7 @@ impl Config {
             detect_profile: self.detect_profile.clone(),
             async_oneside: self.async_oneside,
             filestore: &filestore,
+            additional_configs: self.additional_configs.clone(),
         };
 
         debug!("Attempting to render");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -494,12 +494,8 @@ mod tests {
         let outputs: Vec<Box<dyn output::Output + Send + Sync>> = vec![Box::new(http)];
         let mut cfg = Config::default();
         cfg.additional_configs = vec![
-            AdditionalConfig::String(String::from(
-                "some:\n  random::config",
-            )),
-            AdditionalConfig::String(String::from(
-                "has_a_newline: true",
-            )),
+            AdditionalConfig::String(String::from("some:\n  random::config")),
+            AdditionalConfig::String(String::from("has_a_newline: true")),
         ];
         let rendered = cfg.render(ipc_plugin()).unwrap();
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -68,8 +68,8 @@ impl AdditionalConfig {
 impl std::fmt::Display for AdditionalConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::String(s) => write!(f, "{}", s),
-            Self::IncludePath(path) => write!(f, "include: {:?}", path.as_path()),
+            Self::String(s) => write!(f, "{}\n", s),
+            Self::IncludePath(path) => write!(f, "include: {:?}\n", path.as_path()),
         }
     }
 }
@@ -493,14 +493,21 @@ mod tests {
         http.custom = vec!["Accept-Encoding".to_string()];
         let outputs: Vec<Box<dyn output::Output + Send + Sync>> = vec![Box::new(http)];
         let mut cfg = Config::default();
-        cfg.additional_configs = vec![AdditionalConfig::String(String::from(
-            "some:\n  random::config",
-        ))];
+        cfg.additional_configs = vec![
+            AdditionalConfig::String(String::from(
+                "some:\n  random::config",
+            )),
+            AdditionalConfig::String(String::from(
+                "has_a_newline: true",
+            )),
+        ];
         let rendered = cfg.render(ipc_plugin()).unwrap();
 
-        let regex = regex::Regex::new("some:\n  random::config").unwrap();
+        let first_match = "some:\n  random::config";
+        let second_match = "has_a_newline: true";
 
-        assert!(regex.find(&rendered).is_some());
+        assert!(rendered.find(&first_match).is_some());
+        assert!(rendered.find(&first_match).is_some());
     }
     #[test]
     fn test_render_additional_includes_found_file() {
@@ -514,7 +521,6 @@ mod tests {
         let existes = PathBuf::from(tempfile.path());
         cfg.additional_configs = vec![AdditionalConfig::IncludePath(existes)];
         let rendered = cfg.render(ipc_plugin()).unwrap();
-        println!("Rendered: {}", rendered);
 
         let mat = format!("include: {:?}", tempfile.path());
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,12 +54,10 @@ pub enum AdditionalConfig {
 impl AdditionalConfig {
     pub fn check(&self) -> Result<(), Error> {
         match self {
-            AdditionalConfig::String(_) => {
-                Ok(())
-            }
+            AdditionalConfig::String(_) => Ok(()),
             AdditionalConfig::IncludePath(ref path) => {
                 if path.exists() {
-                    return Ok(())
+                    return Ok(());
                 }
                 return Err(Error::MissingInclude);
             }
@@ -71,7 +69,7 @@ impl std::fmt::Display for AdditionalConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::String(s) => write!(f, "{}", s),
-            Self::IncludePath(path) => write!(f, "include: {:?}", path.as_path())
+            Self::IncludePath(path) => write!(f, "include: {:?}", path.as_path()),
         }
     }
 }
@@ -280,9 +278,10 @@ impl Config {
             .collect();
         let filestore = self.filestore.render(&self.default_log_dir)?;
 
-        self.additional_configs.iter().map(|c|{
-            c.check()
-        }).collect::<Result<(), Error>>()?;
+        self.additional_configs
+            .iter()
+            .map(|c| c.check())
+            .collect::<Result<(), Error>>()?;
 
         let template = ConfigTemplate {
             runmode: self.runmode.clone(),
@@ -494,7 +493,9 @@ mod tests {
         http.custom = vec!["Accept-Encoding".to_string()];
         let outputs: Vec<Box<dyn output::Output + Send + Sync>> = vec![Box::new(http)];
         let mut cfg = Config::default();
-        cfg.additional_configs = vec![AdditionalConfig::String(String::from("some:\n  random::config"))];
+        cfg.additional_configs = vec![AdditionalConfig::String(String::from(
+            "some:\n  random::config",
+        ))];
         let rendered = cfg.render(ipc_plugin()).unwrap();
 
         let regex = regex::Regex::new("some:\n  random::config").unwrap();
@@ -532,9 +533,8 @@ mod tests {
         cfg.additional_configs = vec![AdditionalConfig::IncludePath(missing)];
         let rendered = cfg.render(ipc_plugin());
         match rendered {
-            Err(Error::MissingInclude) => {},
-            _ => panic!("Wrong or missing error for include")
+            Err(Error::MissingInclude) => {}
+            _ => panic!("Wrong or missing error for include"),
         }
     }
-
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,8 @@ pub enum Error {
     Askama(#[from] askama::Error),
     #[error("MissingServerId: {0}")]
     MissingServerId(usize),
+    #[error("Missing Include")]
+    MissingInclude,
     #[error("{0}", msg)]
     Custom { msg: String },
 }

--- a/templates/suricata.yaml.in
+++ b/templates/suricata.yaml.in
@@ -1066,7 +1066,7 @@ reference-config-file: {{ suricata_config_path }}/reference.config
 # searched for in the same directory as this configuration file. You may
 # use absolute pathnames too.
 # You can specify more than 2 configuration files, if needed.
-#include: include1.yaml
+#include: 1.yaml
 #include: include2.yaml
 
 plugins:

--- a/templates/suricata.yaml.in
+++ b/templates/suricata.yaml.in
@@ -1079,3 +1079,9 @@ plugins:
 {% for plugin in plugins %}
 {{ plugin.config }}
 {% endfor %}
+
+## Additional configs rander below
+
+{% for additional_config in additional_configs %}
+{{ additional_config }}
+{% endfor %}


### PR DESCRIPTION
Allow for users to pass in their own `includes` or raw strings to the suricata.yaml. Idea is to give raw access to the config for those that need it.
