### PR TITLE
expose the ipc_to_suricata_channel_size param

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ chrono = "0.4"
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
-packet-ipc = { git = "https://github.com/protectwise/packet-ipc.git", branch = "bounded-channel" }
+packet-ipc = "0.15"
 pin-project = "0.4"
 prost = { version = "0.6", optional = true }
 prost-types = { version = "0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suricata-ipc"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["dbcfd <bdbrowning2@gmail.com>", "kornstar11 <ben@protectwise.com>"]
 edition = "2018"
 description = "Library for sending packets to suricata and receiving output."
@@ -17,7 +17,7 @@ chrono = "0.4"
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
-packet-ipc = "0.14"
+packet-ipc = { git = "https://github.com/protectwise/packet-ipc.git", branch = "bounded-channel" }
 pin-project = "0.4"
 prost = { version = "0.6", optional = true }
 prost-types = { version = "0.6", optional = true }

--- a/plugins/ipc-plugin/ipc-plugin-rs/Cargo.toml
+++ b/plugins/ipc-plugin/ipc-plugin-rs/Cargo.toml
@@ -11,7 +11,7 @@ debug = true
 
 [dependencies]
 log = "0.4"
-packet-ipc = "0.14"
+packet-ipc = { git = "https://github.com/protectwise/packet-ipc.git", branch = "bounded-channel" }
 
 suricata = { path = "/build/suricata/rust" }
 

--- a/plugins/ipc-plugin/ipc-plugin-rs/src/lib.rs
+++ b/plugins/ipc-plugin/ipc-plugin-rs/src/lib.rs
@@ -106,10 +106,14 @@ pub extern "C" fn rs_ipc_populate_packets(ipc: *mut IpcClient, packets: *mut *mu
 }
 
 #[no_mangle]
-pub extern "C" fn rs_create_ipc_client(server_name: *const std::os::raw::c_char, client: *mut *mut IpcClient) -> u32 {
+pub extern "C" fn rs_create_ipc_client(server_name: *const std::os::raw::c_char, client: *mut *mut IpcClient, channel_size: u64) -> u32 {
     let server = unsafe { std::ffi::CStr::from_ptr(server_name) };
     if let Ok(s) = server.to_str() {
-        if let Ok(ipc) = Client::new(s.to_string()) {
+        let channel_size = match channel_size {
+            0 => None,
+            other => Some(other), //bounded
+        };
+        if let Ok(ipc) = Client::new_with_size(s.to_string(), channel_size) {
             let raw = Box::into_raw(Box::new(IpcClient { inner: ipc }));
             unsafe { *client = raw };
             1

--- a/plugins/ipc-plugin/ipc-plugin-rs/src/lib.rs
+++ b/plugins/ipc-plugin/ipc-plugin-rs/src/lib.rs
@@ -113,7 +113,7 @@ pub extern "C" fn rs_create_ipc_client(server_name: *const std::os::raw::c_char,
             0 => None,
             other => Some(other), //bounded
         };
-        if let Ok(ipc) = Client::new_with_size(s.to_string(), channel_size) {
+        if let Ok(ipc) = Client::new_with_size(s.to_string(), channel_size as usize) {
             let raw = Box::into_raw(Box::new(IpcClient { inner: ipc }));
             unsafe { *client = raw };
             1

--- a/plugins/ipc-plugin/ipc-plugin-rs/src/lib.rs
+++ b/plugins/ipc-plugin/ipc-plugin-rs/src/lib.rs
@@ -111,9 +111,9 @@ pub extern "C" fn rs_create_ipc_client(server_name: *const std::os::raw::c_char,
     if let Ok(s) = server.to_str() {
         let channel_size = match channel_size {
             0 => None,
-            other => Some(other), //bounded
+            other => Some(other as usize), //bounded
         };
-        if let Ok(ipc) = Client::new_with_size(s.to_string(), channel_size as usize) {
+        if let Ok(ipc) = Client::new_with_size(s.to_string(), channel_size) {
             let raw = Box::into_raw(Box::new(IpcClient { inner: ipc }));
             unsafe { *client = raw };
             1

--- a/plugins/ipc-plugin/src/runmode-ipc.c
+++ b/plugins/ipc-plugin/src/runmode-ipc.c
@@ -19,6 +19,8 @@
 #include "util-device.h"
 #include <stdio.h>
 
+extern intmax_t max_pending_packets;
+
 void InitializeRunMode() {
     int live_mode = 1;
     int conf_live_mode = 0;
@@ -125,6 +127,11 @@ static void *ParseIpcConfig(const char *servers)
     conf->allocation_batch = 100; // TODO Error if greater than the max_pending_packets setting.
     if(ConfGetInt("ipc-plugin.allocation-batch-size", &conf->allocation_batch) == 0) {
         SCLogInfo("No ipc-plugin.allocation-batch-size parameters, defaulting to 100");
+    }
+
+    if(max_pending_packets <= conf->allocation_batch) {
+        SCLogError(SC_ERR_RUNMODE, "Runmode start failed: max-pending-packets need to be higher than allocation-batch-size");
+        return NULL;
     }
 
     conf->ipc_to_suricata_channel_size = 5;

--- a/plugins/ipc-plugin/src/runmode-ipc.c
+++ b/plugins/ipc-plugin/src/runmode-ipc.c
@@ -122,9 +122,14 @@ static void *ParseIpcConfig(const char *servers)
 
     SCFree(servers_conf);
 
-    conf->allocation_batch = 100;
+    conf->allocation_batch = 100; // TODO Error if greater than the max_pending_packets setting.
     if(ConfGetInt("ipc-plugin.allocation-batch-size", &conf->allocation_batch) == 0) {
         SCLogInfo("No ipc-plugin.allocation-batch-size parameters, defaulting to 100");
+    }
+
+    conf->ipc_to_suricata_channel_size = 5;
+    if(ConfGetInt("ipc-plugin.ipc_to_suricata_channel_size", &conf->ipc_to_suricata_channel_size) == 0) {
+        SCLogInfo("No ipc-plugin.ipc_to_suricata_channel_size parameters, defaulting to 5");
     }
 
     conf->DerefFunc = IpcDerefConfig;

--- a/plugins/ipc-plugin/src/runmode-ipc.h
+++ b/plugins/ipc-plugin/src/runmode-ipc.h
@@ -12,6 +12,8 @@ typedef struct IpcConfig_
     int nb_servers;
     /* Packet allocation batch size, defaults to 100 */
     intmax_t allocation_batch;
+    /* How large should the channel between ipc channel and suricata packet pool be. This channel contains batches of packets, NOT individual packets or bytes. 0 is unbounded. */
+    intmax_t ipc_to_suricata_channel_size;
 
     /* ref counter for shared config */
     SC_ATOMIC_DECLARE(unsigned int, ref);

--- a/plugins/ipc-plugin/src/source-ipc.c
+++ b/plugins/ipc-plugin/src/source-ipc.c
@@ -216,7 +216,7 @@ TmEcode ReceiveIpcThreadInit(ThreadVars *tv, const void *initdata, void **data)
         SCLogError(SC_ERR_RUNMODE, "Thread init failed");
         SCReturnInt(TM_ECODE_FAILED);
     }
-    SCLogInfo("Creating client to %s", ptv->server_name);
+    SCLogInfo("Creating client to %s (channel size: %d)", ptv->server_name, ipc->ipc_to_suricata_channel_size);
 
     if(!rs_create_ipc_client(ptv->server_name, &ipc_client, ipc->ipc_to_suricata_channel_size)) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to connect to client at %s", ptv->server_name);

--- a/plugins/ipc-plugin/src/source-ipc.c
+++ b/plugins/ipc-plugin/src/source-ipc.c
@@ -218,7 +218,7 @@ TmEcode ReceiveIpcThreadInit(ThreadVars *tv, const void *initdata, void **data)
     }
     SCLogInfo("Creating client to %s", ptv->server_name);
 
-    if(!rs_create_ipc_client(ptv->server_name, &ipc_client)) {
+    if(!rs_create_ipc_client(ptv->server_name, &ipc_client, ipc->ipc_to_suricata_channel_size)) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to connect to client at %s", ptv->server_name);
         SCFree(ptv->server_name);
         SCFree(ptv);

--- a/src/config/ipc_plugin.rs
+++ b/src/config/ipc_plugin.rs
@@ -9,6 +9,7 @@ pub struct IpcPluginConfig {
     pub allocation_batch_size: usize,
     pub servers: usize,
     pub live: bool,
+    pub ipc_to_suricata_channel_size: usize,
 }
 
 impl Default for IpcPluginConfig {
@@ -29,6 +30,7 @@ impl IpcPluginConfig {
             allocation_batch_size: 1_000,
             servers: 1,
             live: true,
+            ipc_to_suricata_channel_size: 5,
         }
     }
 
@@ -47,6 +49,7 @@ impl IpcPluginConfig {
             allocation_batch_size: self.allocation_batch_size,
             servers: names,
             live: self.live,
+            ipc_to_suricata_channel_size: self.ipc_to_suricata_channel_size,
         };
         Ok((plugin, servers))
     }
@@ -59,6 +62,7 @@ pub struct IpcPlugin {
     pub allocation_batch_size: usize,
     pub servers: String,
     pub live: bool,
+    pub ipc_to_suricata_channel_size: usize,
 }
 
 impl Plugin for IpcPlugin {

--- a/templates/ipc-plugin.yaml.in
+++ b/templates/ipc-plugin.yaml.in
@@ -1,4 +1,5 @@
 ipc-plugin:
   live: {{ live }}
   allocation-batch-size: {{ allocation_batch_size }}
+  ipc_to_suricata_channel_size: {{ ipc_to_suricata_channel_size }}
   servers: "{{ servers }}"


### PR DESCRIPTION
allows users to use a bounded channel for packet batch transfers between packet-ipc thread and suricata.